### PR TITLE
Add Warp terminal theme

### DIFF
--- a/warp/README.md
+++ b/warp/README.md
@@ -1,0 +1,11 @@
+# Pierre Theme for Warp
+
+## Install
+
+Copy the theme YAML files to your Warp themes directory:
+
+- **macOS**: `~/.warp/themes/`
+- **Windows**: `%APPDATA%\warp\Warp\data\themes\`
+- **Linux**: `${XDG_DATA_HOME:-~/.local/share}/warp-terminal/themes/`
+
+Then open Warp → Settings → Appearance → Themes and select **Pierre Dark** or **Pierre Light**.

--- a/warp/README.md
+++ b/warp/README.md
@@ -9,3 +9,7 @@ Copy the theme YAML files to your Warp themes directory:
 - **Linux**: `${XDG_DATA_HOME:-~/.local/share}/warp-terminal/themes/`
 
 Then open Warp → Settings → Appearance → Themes and select **Pierre Dark** or **Pierre Light**.
+
+## Source
+
+Theme colors are derived from the [Pierre Theme](https://github.com/pierrecomputer/theme) for Visual Studio Code, built by [The Pierre Computer Company](https://pierre.computer). Custom theme format follows the [Warp documentation](https://docs.warp.dev/terminal/appearance/custom-themes).

--- a/warp/pierre_dark.yaml
+++ b/warp/pierre_dark.yaml
@@ -1,0 +1,25 @@
+name: Pierre Dark
+accent: '#009fff'
+cursor: '#009fff'
+background: '#070707'
+foreground: '#fbfbfb'
+details: darker
+terminal_colors:
+  normal:
+    black: '#141415'
+    red: '#ff2e3f'
+    green: '#0dbe4e'
+    yellow: '#ffca00'
+    blue: '#009fff'
+    magenta: '#c635e4'
+    cyan: '#08c0ef'
+    white: '#c6c6c8'
+  bright:
+    black: '#141415'
+    red: '#ff2e3f'
+    green: '#0dbe4e'
+    yellow: '#ffca00'
+    blue: '#009fff'
+    magenta: '#c635e4'
+    cyan: '#08c0ef'
+    white: '#c6c6c8'

--- a/warp/pierre_light.yaml
+++ b/warp/pierre_light.yaml
@@ -1,0 +1,25 @@
+name: Pierre Light
+accent: '#009fff'
+cursor: '#009fff'
+background: '#ffffff'
+foreground: '#070707'
+details: lighter
+terminal_colors:
+  normal:
+    black: '#1F1F21'
+    red: '#ff2e3f'
+    green: '#0dbe4e'
+    yellow: '#ffca00'
+    blue: '#009fff'
+    magenta: '#c635e4'
+    cyan: '#08c0ef'
+    white: '#c6c6c8'
+  bright:
+    black: '#1F1F21'
+    red: '#ff2e3f'
+    green: '#0dbe4e'
+    yellow: '#ffca00'
+    blue: '#009fff'
+    magenta: '#c635e4'
+    cyan: '#08c0ef'
+    white: '#c6c6c8'


### PR DESCRIPTION
## Summary

- Add Pierre Dark and Pierre Light themes for [Warp](https://www.warp.dev/) terminal
- Colors are derived from the existing VS Code terminal ANSI colors in `themes/pierre-dark.json` and `themes/pierre-light.json`
- Includes a README with install instructions for macOS, Windows, and Linux

## Files added

- `warp/pierre_dark.yaml`
- `warp/pierre_light.yaml`
- `warp/README.md`